### PR TITLE
Add arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@ add_executable(cli src/main.cpp build/cli.hpp)
 configure_file(cli_config.h.in ../src/cli_config.h)
 
 #Test target
-#add_executable(
-#        test
-#        tests/test.cpp src/Cli/Cli.cpp src/Cli/Cli.hpp src/Flag/Flag.cpp src/Flag/Flag.hpp src/Command/Command.cpp src/Command/Command.hpp)
-
 add_executable(
        test
        tests/test.cpp build/cli.hpp)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ command(name, description, example, {flags}, action, argumentsCount = 0, canCont
 | `flags`                       | `Flags`           | задаются флаги                                                                                              |
 | `action`                      | `CommandCallback` | имя функции, которая будет выполняться при вызове данной команды                                            |
 | `argumentsCount`              | `int`             | кол-во аргументов, которые команда может принять (если указать `-1`, то кол-во аргументов может быть любое) |
-| `canContainEmptyArgumentList` | `bool`            | флаг, разрешающий не принимать аргументов (имеет значение только если `argumentsCount = -1`)                |
+| `canContainEmptyArgumentList` | `bool`            | флаг, разрешающий не принимать аргументов (имеет значение если `argumentsCount = -1`)                |
   
 >```c++
 >❗ Тип Flags - множество объектов класса Flag (как определять Flag показывается ниже)
@@ -342,7 +342,7 @@ ERROR: Command "printTwoArguments" must contain 2 arguments
 
 
 ```
-$ ./cli printFlagsAndArguments file1.txt --dir directory/ file2.txt"
+$ ./cli printFlagsAndArguments file1.txt --dir directory/ file2.txt
 Flags: 
 dir -> directory/
 Arguments: 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ $ make clean
 
 # Описание
 
-При использовании CLI стоит различать два понятия `команда` и `флаг`.
-Нужно понимать, что пользователь вводит `команду`, когда хочет выполнить какое-то действие, а `флаг` он вводит для того, чтобы указать, что действие `команды` будет выполняться по каким-то правилам и с какими-то переданными значениями. \
+При использовании CLI стоит различать три понятия `команда`, `аргумент` и `флаг`.
+Нужно понимать, что пользователь вводит `команду`, когда хочет выполнить какое-то действие, `аргумент`, чтобы передать в `команду` информацию с которой в дальнейшем работать, а `флаг` он вводит для того, чтобы указать, что действие `команды` будет выполняться по каким-то правилам и с какими-то переданными значениями. \
 Исходя из вышесказанного, можно вывести одно очень простое правило: 
 
-> ❗ Команда может содержать некое количество флагов, но не наоборот.
+> ❗ Команда может содержать некое количество флагов и аргументов, но никак иначе.
 
 ### Некоторые правила использования:
 
@@ -120,15 +120,17 @@ auto cli = cli::Cli();
 2. Чтобы описать `команду` нужно использовать следующий синтаксис: 
 
 ```c++
-command(name, description, example, {flags}, action);
+command(name, description, example, {flags}, action, argumentsCount = 0, canContainEmptyArgumentList = false);
 ```
-| Поле          | Тип               | Описание                                                         |
-|---------------|-------------------|------------------------------------------------------------------|
-| `name`        | `string`          | имя команды                                                      |
-| `description` | `string`          | описание команды                                                 |
-| `example`     | `string`          | пример использования команды                                     |
-| `flags`       | `Flags`           | задаются флаги                                                   |
-| `action`      | `CommandCallback` | имя функции, которая будет выполняться при вызове данной команды |
+| Поле                          | Тип               | Описание                                                                                                    |
+|-------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------|
+| `name`                        | `string`          | имя команды                                                                                                 |
+| `description`                 | `string`          | описание команды                                                                                            |
+| `example`                     | `string`          | пример использования команды                                                                                |
+| `flags`                       | `Flags`           | задаются флаги                                                                                              |
+| `action`                      | `CommandCallback` | имя функции, которая будет выполняться при вызове данной команды                                            |
+| `argumentsCount`              | `int`             | кол-во аргументов, которые команда может принять (если указать `-1`, то кол-во аргументов может быть любое) |
+| `canContainEmptyArgumentList` | `bool`            | флаг, разрешающий не принимать аргументов (имеет значение только если `argumentsCount = -1`)                |
   
 >```c++
 >❗ Тип Flags - множество объектов класса Flag (как определять Flag показывается ниже)
@@ -180,37 +182,67 @@ Flag(name, shortName, description, isRequired, withValue)
 # Пример использования
 
 ```c++
-#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
+#include "../build/cli.hpp" // Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
-void func(cli::FlagsType &parsedFlags); // Объявляем функцию, которая будет вызывать при вызове команды printHello
-void func2(cli::FlagsType &parsedFlags);// Объявляем функцию, которая будет вызывать при вызове команды printName
+
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printHello
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printName
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
 
 int main(int argc, char **argv) {
-    auto cli = cli::Cli();
-    cli.setDescriptionMaxWidth(7); // Устанавливаем ширину поля под описание в 7 символов 
+    auto cli = cli::Cli();         // Создаём объект класса Cli
+    cli.setDescriptionMaxWidth(7); // Задаём ширину описания
+
     try {
-        cli.command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func)// Добавляем команду printHello
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1) // Добавляем команду printArguments
+           .command("printTwoArguments", "Displays the passed arguments", "", {}, func, 2)                                                                              // Добавляем команду printTwoArguments
+           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                              // Добавляем команду printHello
            .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
-                {
-                    cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),
-                    cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)
-                },func2)                           // Добавляем команду printName и указываем флаги name и surname
-                .parse(argc, argv);                // Обязательно вызываем функцию parse c аргументами argc и argv
-    } catch (const std::invalid_argument &error) { // Обрабатываем какие-либо ошибки
-        std::cout << error.what() << "\n"; // Обязательно при выводе ошибок поставить символ переноса строки, иначе возможен вывод странных символов
-        return 2; // Код завершения программы при ошибке
+                         {
+                                 cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),                                                            // Объявляем флаг "--name" для команды printName
+                                 cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)                                                      // Объявляем флаг "--surname" для команды printName
+                         }, func3)                                                                                                                                      // Добавляем команду printName и указываем флаги name и surname
+           .command("printFlagsAndArguments", "Displays the passed flags and arguments", "$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
+                         {
+                                 cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),                                                       // Объявляем флаг "--dir" для команды printName
+                         }, func4, -1)                                                                                                                                  // Добавляем команду printFlagsAndArguments
+                .parse(argc, argv);                                                                                                                                     // Обязательно вызываем функцию parse c аргументами argc и argv
+    } catch (const std::invalid_argument &error) {                                                                                                                      // Обрабатываем какие-либо ошибки
+        std::cout << error.what() << "\n";                                                                                                                              // Обязательно при выводе ошибок поставить символ переноса строки, иначе возможен вывод странных символов
+        return 2;                                                                                                                                                       // код завершения программы при ошибке
     }
     return 0;
 }
 
-void func(cli::FlagsType &parsedFlags) { // Определение функции команды printHello
+
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printArguments
+    std::cout << "Arguments: \n";
+    for (auto &arg : parsedArguments) {
+        std::cout << arg << "\n";
+    }
+}
+
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printHello
     std::cout << "Hello!\n";
 }
 
-void func2(cli::FlagsType &parsedFlags) { // Определение функции команды printName
-    std::cout << "Hello " << parsedFlags.at("name").value << " " << parsedFlags.at("surname").value << "!\n";
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printName
+    std::cout << "Hello "
+              << parsedFlags.at("name").value << " "
+              << parsedFlags.at("surname").value << "!\n";
 }
 
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printFlagsAndArguments
+    std::cout << "Flags: \n";
+    for (auto &flag : parsedFlags) {
+        std::cout << flag.first << " -> " << flag.second.value << "\n";
+    }
+    std::cout << "Arguments: \n";
+    for (auto &arg : parsedArguments) {
+        std::cout << arg << "\n";
+    }
+}
 ```
 
 ### Примеры запуска в терминале:
@@ -227,18 +259,49 @@ Hello Vanya Sidorov!
 
 ```
 $ ./cli help
-CLI version 0.2.0
+CLI version 0.2.1
 
 Usage:
    command [flags] [arguments]
 
 Commands:
-  help                               Displays background information and prompts all kinds of commands
-  printHello                         Displays the word "Hello!"
-  printName                          Displays "Hello [entered name]!"
+  help                               Show help 
+                                     informa-
+                                     tion. 
+  printArguments                     Displays 
+                                     the passed
+                                     arguments
+  printFlagsAndArguments             Displays 
+                                     the passed
+                                     flags and
+                                     arguments
     Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that accepts a name as input
-      -s, --surname=VALUE[REQUIRED]  A flag that accepts a surname for entry
+      -d, --dir=VALUE                A flag  
+                                     that acc-
+                                     epts a 
+                                     directory
+                                     as input.
+  printHello                         Displays 
+                                     the word
+                                     "Hello!".
+  printName                          Displays 
+                                     "Hello 
+                                     [entered
+                                     name]!".
+    Flags:
+      -n, --name=VALUE[REQUIRED]     A flag  
+                                     that acc-
+                                     epts a 
+                                     name as 
+                                     input. 
+      -s, --surname=VALUE[REQUIRED]  A flag  
+                                     that acc-
+                                     epts a 
+                                     surname
+                                     for entry.
+  printTwoArguments                  Displays 
+                                     the passed
+                                     arguments
 ```
 
 ```
@@ -263,8 +326,29 @@ ERROR: Required flag not entered -> "--name" OR "-n"
 ```
 
 ```
-./cli printName -n --nocolor
+$ ./cli printName -n --nocolor
 ERROR: Flag "--name" must accept an argument
+```
+
+```
+$ ./cli --nocolor printArguments
+ERROR: Command "printArguments" must contain at least one argument
+```
+
+```
+$ ./cli --nocolor printTwoArguments a
+ERROR: Command "printTwoArguments" must contain 2 arguments
+```
+
+
+```
+$ ./cli printFlagsAndArguments file1.txt --dir directory/ file2.txt"
+Flags: 
+dir -> directory/
+Arguments: 
+file1.txt
+file2.txt
+
 ```
 
 [🔝Оглавление](#оглавление)

--- a/build/cli.hpp
+++ b/build/cli.hpp
@@ -33,25 +33,28 @@ namespace cli {
 namespace cli {
 
     using FlagsType = std::map<std::string, Flag>;
-    using CommandCallback = std::function<void(FlagsType &)>;
+    using ArgumentsType = std::vector<std::string>;
+    using CommandCallback = std::function<void(FlagsType &, ArgumentsType &)>;
 
     class Command {
     public:
         std::string name;
         std::string description;
         std::string example;
-        std::map<std::string, Flag> commandFlags;
+        std::map<std::string, Flag> flags;
         CommandCallback action;
+        int argumentsCount;
+        bool canContainEmptyArgumentList;
 
     public:
-        Command(std::string name, std::string description, std::string example, const std::vector<Flag> &commandFlags, CommandCallback action)
-            : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)) {
-            for (auto &flag : commandFlags) {
-                this->commandFlags.insert(std::make_pair(flag.name, flag));
+        Command(std::string name, std::string description, std::string example, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
+            for (auto &flag : flags) {
+                this->flags.insert(std::make_pair(flag.name, flag));
             }
         };
     };
-}
+}// namespace cli
 
 
 
@@ -66,7 +69,7 @@ namespace cli {
                 {"blue", "\x1B[34m"},
                 {"white", "\x1B[37m"}};
 
-        Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action);
+        Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &setDescriptionMaxWidth(int value = 50);
 
         void parse(int &argc, char **argv);
@@ -78,17 +81,19 @@ namespace cli {
         static void checkNocolor(cli::Cli &cli, int &argc, char **argv);
         static std::string paint(const std::string &str, const std::string &color, cli::Cli &cli);
         static void lineWrapping(std::string &description, int maxSize, int flagSize, cli::Cli &cli);
+        void parseFlagsAndArguments(std::string &cmd, int argc, char** argv, int &i, FlagsType &commandFlags, FlagsType &parsedFlags, ArgumentsType &parsedArguments);
+        std::string checkNumberOfArgumentsPassed(std::string &cmd, ArgumentsType &parsedArguments);
 
     private:
         int descriptionMaxWidth = 50;
         std::map<std::string, Command> commands = {std::make_pair("help", Command("help", "Show help information.", "", {},
-                                                                                  [this](FlagsType &parsedFlags) {
+                                                                                  [this](FlagsType &parsedFlags, ArgumentsType &parsedArguments) {
                                                                                       printAllHelp(this->commands, *this);
                                                                                   }))};
     };
 }// namespace cli
-cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action) {
-    Command cmd = Command(name, description, example, commandFlag, action);
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, example, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
     commands.insert(std::make_pair(name, cmd));
     return *this;
 }
@@ -122,7 +127,7 @@ std::string cli::Cli::flagInCommand(std::map<std::string, Flag> &commandFlags, s
 
 void cli::Cli::checkNocolor(cli::Cli &cli, int &argc, char **argv) {
     std::string cmd;
-    for (int i = 0; i < argc; ++i) {
+    for (int i = 1; i < argc; ++i) {
         cmd = argv[i];
         if (cmd == "--nocolor") {
             cli.nocolor = true;
@@ -134,9 +139,57 @@ void cli::Cli::checkNocolor(cli::Cli &cli, int &argc, char **argv) {
     }
 }
 
+std::string cli::Cli::checkNumberOfArgumentsPassed(std::string &cmd, cli::ArgumentsType &parsedArguments) {
+    auto sizeCmdArguments = commands.at(cmd).argumentsCount;
+    auto countParsedArguments = parsedArguments.size();
+
+    if (sizeCmdArguments == -1) {
+        if (!commands.at(cmd).canContainEmptyArgumentList && countParsedArguments == 0) {
+            return paint(R"(ERROR: Command ")" + cmd + R"(" must contain at least one argument)", "red", *this);
+        }
+    } else if (sizeCmdArguments != countParsedArguments) {
+        std::string argWord = (sizeCmdArguments > 1) ? "arguments" : "argument";
+        return paint(R"(ERROR: Command ")" + cmd + R"(" must contain )" + std::to_string(sizeCmdArguments) + ' ' + argWord, "red", *this);
+    }
+    return "";
+}
+
+void cli::Cli::parseFlagsAndArguments(std::string &cmd, int argc, char** argv, int &i, FlagsType &commandFlags, FlagsType &parsedFlags, ArgumentsType &parsedArguments) {
+    while (++i < argc) {
+        std::string lexeme = argv[i];
+        if (lexeme[0] == '-') {
+            std::string flag = lexeme;
+            lexeme.erase(std::remove(lexeme.begin(), lexeme.begin() + 2, '-'), lexeme.begin() + 2);
+            if ((lexeme = flagInCommand(commandFlags, lexeme)).empty()) {
+                throw std::invalid_argument(paint(R"(ERROR: An unknown flag has been entered for the command ")" + cmd + R"(" -> ")" + flag + R"(")", "red", *this));
+            }
+            auto commandFlag = commandFlags.at(lexeme);
+            if (commandFlag.withValue) {
+                ++i;
+                if (i == argc) {
+                    throw std::invalid_argument(paint(R"(ERROR: Flag "--)" + lexeme + R"(" must accept an argument)", "red", *this));
+                }
+                commandFlag.value = argv[i];
+            }
+            parsedFlags.insert({lexeme, commandFlag});
+        } else {
+            parsedArguments.push_back(lexeme);
+        }
+    }
+
+    std::string message = checkIsRequiredFlag(parsedFlags, commandFlags, *this);
+    if (!message.empty()) {
+        throw std::invalid_argument(message);
+    }
+
+    message = checkNumberOfArgumentsPassed(cmd, parsedArguments);
+    if (!message.empty()) {
+        throw std::invalid_argument(message);
+    }
+}
+
 void cli::Cli::parse(int &argc, char **argv) {
     std::string cmd;
-    std::string message;
     checkNocolor(*this, argc, argv);
     for (int i = 1; i < argc; ++i) {
         cmd = argv[i];
@@ -156,34 +209,13 @@ void cli::Cli::parse(int &argc, char **argv) {
                 printCmdHelp(enteredCommands, commands, *this);
                 break;
             }
-            auto commandFlags = commands.at(cmd).commandFlags;
-            std::map<std::string, Flag> flags;
-            if (!commandFlags.empty()) {
-                std::string flag;
-                while (i + 1 < argc && !(flag = argv[i + 1]).empty() && flag[0] == '-' && ++i) {
-                    std::string inputFlagName = flag;
-                    inputFlagName.erase(std::remove(inputFlagName.begin(), inputFlagName.begin() + 2, '-'), inputFlagName.begin() + 2);
-                    if ((inputFlagName = flagInCommand(commandFlags, inputFlagName)).empty()) {
-                        throw std::invalid_argument(paint(R"(ERROR: An unknown flag has been entered for the command ")" + cmd + R"(" -> ")" + flag + R"(")", "red", *this));
-                    }
-                    auto commandFlag = commandFlags.at(inputFlagName);
-                    if (commandFlag.withValue) {
-                        ++i;
-                        if (i == argc) {
-                            throw std::invalid_argument(paint(R"(ERROR: Flag "--)" + inputFlagName + R"(" must accept an argument)", "red", *this));
-                        }
-                        commandFlag.value = argv[i];
-                    }
-                    flags.insert({inputFlagName, commandFlag});
-                }
-                message = checkIsRequiredFlag(flags, commandFlags, *this);
-                if (!message.empty()) {
-                    throw std::invalid_argument(message);
-                }
-            }
+            auto commandFlags = commands.at(cmd).flags;
+            ArgumentsType parsedArguments;
+            FlagsType parsedFlags;
+            parseFlagsAndArguments(cmd, argc, argv, i, commandFlags, parsedFlags, parsedArguments);
             auto action = commands.at(cmd).action;
             if (action) {
-                action(flags);
+                action(parsedFlags, parsedArguments);
             }
         } else {
             if (cmd[0] == '-') {
@@ -277,10 +309,11 @@ void cli::Cli::printAllHelp(std::map<std::string, Command> &commands, cli::Cli &
         } else {
             lineWrapping(cmdDescription, maxSize, cmdSize, cli);
         }
-        if (!cmd.second.commandFlags.empty()) {
+        auto commandFlags = cmd.second.flags;
+        if (!commandFlags.empty()) {
             std::cout << paint("    Flags:\n", "yellow", cli);
         }
-        for (auto &flag : cmd.second.commandFlags) {
+        for (auto &flag : commandFlags) {
             str = "      -" + flag.second.shortName + ", --" + flag.first;
             if (flag.second.withValue) {
                 str += "=VALUE";
@@ -310,7 +343,7 @@ std::map<std::string, int> cli::Cli::getCmdSizes(std::map<std::string, Command> 
     std::map<std::string, int> actualSize;
     for (auto &cmd : commands) {
         actualSize.insert(std::make_pair(cmd.first, (int) cmd.first.size() + 2));
-        for (auto &flag : cmd.second.commandFlags) {
+        for (auto &flag : cmd.second.flags) {
             int flagSize = (int) (flag.first.size() + flag.second.shortName.size() + 11);// 11 - number of special characters (spaces, commas, hyphens)
             if (flag.second.withValue) {
                 flagSize += 6;// "=VALUE" == 6
@@ -356,10 +389,11 @@ void cli::Cli::printCmdHelp(std::vector<std::string> &commandsName, std::map<std
             lineWrapping(cmdDescription, maxSize, cmdSize, cli);
         }
 
-        if (!cmd.commandFlags.empty()) {
+        auto commandFlags = cmd.flags;
+        if (!commandFlags.empty()) {
             std::cout << paint("\tFlags:\n", "yellow", cli);
         }
-        for (auto &flag : cmd.commandFlags) {
+        for (auto &flag : commandFlags) {
             str = "      -" + flag.second.shortName + ", --" + flag.first;
             if (flag.second.withValue) {
                 str += "=VALUE";

--- a/src/Cli/Cli.cpp
+++ b/src/Cli/Cli.cpp
@@ -1,7 +1,7 @@
 #include "Cli.hpp"
 
-cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action) {
-    Command cmd = Command(name, description, example, commandFlag, action);
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, example, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
     commands.insert(std::make_pair(name, cmd));
     return *this;
 }
@@ -35,7 +35,7 @@ std::string cli::Cli::flagInCommand(std::map<std::string, Flag> &commandFlags, s
 
 void cli::Cli::checkNocolor(cli::Cli &cli, int &argc, char **argv) {
     std::string cmd;
-    for (int i = 0; i < argc; ++i) {
+    for (int i = 1; i < argc; ++i) {
         cmd = argv[i];
         if (cmd == "--nocolor") {
             cli.nocolor = true;
@@ -47,9 +47,57 @@ void cli::Cli::checkNocolor(cli::Cli &cli, int &argc, char **argv) {
     }
 }
 
+std::string cli::Cli::checkNumberOfArgumentsPassed(std::string &cmd, cli::ArgumentsType &parsedArguments) {
+    auto sizeCmdArguments = commands.at(cmd).argumentsCount;
+    auto countParsedArguments = parsedArguments.size();
+
+    if (sizeCmdArguments == -1) {
+        if (!commands.at(cmd).canContainEmptyArgumentList && countParsedArguments == 0) {
+            return paint(R"(ERROR: Command ")" + cmd + R"(" must contain at least one argument)", "red", *this);
+        }
+    } else if (sizeCmdArguments != countParsedArguments) {
+        std::string argWord = (sizeCmdArguments > 1) ? "arguments" : "argument";
+        return paint(R"(ERROR: Command ")" + cmd + R"(" must contain )" + std::to_string(sizeCmdArguments) + ' ' + argWord, "red", *this);
+    }
+    return "";
+}
+
+void cli::Cli::parseFlagsAndArguments(std::string &cmd, int argc, char** argv, int &i, FlagsType &commandFlags, FlagsType &parsedFlags, ArgumentsType &parsedArguments) {
+    while (++i < argc) {
+        std::string lexeme = argv[i];
+        if (lexeme[0] == '-') {
+            std::string flag = lexeme;
+            lexeme.erase(std::remove(lexeme.begin(), lexeme.begin() + 2, '-'), lexeme.begin() + 2);
+            if ((lexeme = flagInCommand(commandFlags, lexeme)).empty()) {
+                throw std::invalid_argument(paint(R"(ERROR: An unknown flag has been entered for the command ")" + cmd + R"(" -> ")" + flag + R"(")", "red", *this));
+            }
+            auto commandFlag = commandFlags.at(lexeme);
+            if (commandFlag.withValue) {
+                ++i;
+                if (i == argc) {
+                    throw std::invalid_argument(paint(R"(ERROR: Flag "--)" + lexeme + R"(" must accept an argument)", "red", *this));
+                }
+                commandFlag.value = argv[i];
+            }
+            parsedFlags.insert({lexeme, commandFlag});
+        } else {
+            parsedArguments.push_back(lexeme);
+        }
+    }
+
+    std::string message = checkIsRequiredFlag(parsedFlags, commandFlags, *this);
+    if (!message.empty()) {
+        throw std::invalid_argument(message);
+    }
+
+    message = checkNumberOfArgumentsPassed(cmd, parsedArguments);
+    if (!message.empty()) {
+        throw std::invalid_argument(message);
+    }
+}
+
 void cli::Cli::parse(int &argc, char **argv) {
     std::string cmd;
-    std::string message;
     checkNocolor(*this, argc, argv);
     for (int i = 1; i < argc; ++i) {
         cmd = argv[i];
@@ -69,34 +117,13 @@ void cli::Cli::parse(int &argc, char **argv) {
                 printCmdHelp(enteredCommands, commands, *this);
                 break;
             }
-            auto commandFlags = commands.at(cmd).commandFlags;
-            std::map<std::string, Flag> flags;
-            if (!commandFlags.empty()) {
-                std::string flag;
-                while (i + 1 < argc && !(flag = argv[i + 1]).empty() && flag[0] == '-' && ++i) {
-                    std::string inputFlagName = flag;
-                    inputFlagName.erase(std::remove(inputFlagName.begin(), inputFlagName.begin() + 2, '-'), inputFlagName.begin() + 2);
-                    if ((inputFlagName = flagInCommand(commandFlags, inputFlagName)).empty()) {
-                        throw std::invalid_argument(paint(R"(ERROR: An unknown flag has been entered for the command ")" + cmd + R"(" -> ")" + flag + R"(")", "red", *this));
-                    }
-                    auto commandFlag = commandFlags.at(inputFlagName);
-                    if (commandFlag.withValue) {
-                        ++i;
-                        if (i == argc) {
-                            throw std::invalid_argument(paint(R"(ERROR: Flag "--)" + inputFlagName + R"(" must accept an argument)", "red", *this));
-                        }
-                        commandFlag.value = argv[i];
-                    }
-                    flags.insert({inputFlagName, commandFlag});
-                }
-                message = checkIsRequiredFlag(flags, commandFlags, *this);
-                if (!message.empty()) {
-                    throw std::invalid_argument(message);
-                }
-            }
+            auto commandFlags = commands.at(cmd).flags;
+            ArgumentsType parsedArguments;
+            FlagsType parsedFlags;
+            parseFlagsAndArguments(cmd, argc, argv, i, commandFlags, parsedFlags, parsedArguments);
             auto action = commands.at(cmd).action;
             if (action) {
-                action(flags);
+                action(parsedFlags, parsedArguments);
             }
         } else {
             if (cmd[0] == '-') {
@@ -190,10 +217,11 @@ void cli::Cli::printAllHelp(std::map<std::string, Command> &commands, cli::Cli &
         } else {
             lineWrapping(cmdDescription, maxSize, cmdSize, cli);
         }
-        if (!cmd.second.commandFlags.empty()) {
+        auto commandFlags = cmd.second.flags;
+        if (!commandFlags.empty()) {
             std::cout << paint("    Flags:\n", "yellow", cli);
         }
-        for (auto &flag : cmd.second.commandFlags) {
+        for (auto &flag : commandFlags) {
             str = "      -" + flag.second.shortName + ", --" + flag.first;
             if (flag.second.withValue) {
                 str += "=VALUE";
@@ -223,7 +251,7 @@ std::map<std::string, int> cli::Cli::getCmdSizes(std::map<std::string, Command> 
     std::map<std::string, int> actualSize;
     for (auto &cmd : commands) {
         actualSize.insert(std::make_pair(cmd.first, (int) cmd.first.size() + 2));
-        for (auto &flag : cmd.second.commandFlags) {
+        for (auto &flag : cmd.second.flags) {
             int flagSize = (int) (flag.first.size() + flag.second.shortName.size() + 11);// 11 - number of special characters (spaces, commas, hyphens)
             if (flag.second.withValue) {
                 flagSize += 6;// "=VALUE" == 6
@@ -269,10 +297,11 @@ void cli::Cli::printCmdHelp(std::vector<std::string> &commandsName, std::map<std
             lineWrapping(cmdDescription, maxSize, cmdSize, cli);
         }
 
-        if (!cmd.commandFlags.empty()) {
+        auto commandFlags = cmd.flags;
+        if (!commandFlags.empty()) {
             std::cout << paint("\tFlags:\n", "yellow", cli);
         }
-        for (auto &flag : cmd.commandFlags) {
+        for (auto &flag : commandFlags) {
             str = "      -" + flag.second.shortName + ", --" + flag.first;
             if (flag.second.withValue) {
                 str += "=VALUE";

--- a/src/Cli/Cli.hpp
+++ b/src/Cli/Cli.hpp
@@ -17,7 +17,7 @@ namespace cli {
                 {"blue", "\x1B[34m"},
                 {"white", "\x1B[37m"}};
 
-        Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action);
+        Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &setDescriptionMaxWidth(int value = 50);
 
         void parse(int &argc, char **argv);
@@ -29,11 +29,13 @@ namespace cli {
         static void checkNocolor(cli::Cli &cli, int &argc, char **argv);
         static std::string paint(const std::string &str, const std::string &color, cli::Cli &cli);
         static void lineWrapping(std::string &description, int maxSize, int flagSize, cli::Cli &cli);
+        void parseFlagsAndArguments(std::string &cmd, int argc, char** argv, int &i, FlagsType &commandFlags, FlagsType &parsedFlags, ArgumentsType &parsedArguments);
+        std::string checkNumberOfArgumentsPassed(std::string &cmd, ArgumentsType &parsedArguments);
 
     private:
         int descriptionMaxWidth = 50;
         std::map<std::string, Command> commands = {std::make_pair("help", Command("help", "Show help information.", "", {},
-                                                                                  [this](FlagsType &parsedFlags) {
+                                                                                  [this](FlagsType &parsedFlags, ArgumentsType &parsedArguments) {
                                                                                       printAllHelp(this->commands, *this);
                                                                                   }))};
     };

--- a/src/Command/Command.hpp
+++ b/src/Command/Command.hpp
@@ -10,22 +10,25 @@
 namespace cli {
 
     using FlagsType = std::map<std::string, Flag>;
-    using CommandCallback = std::function<void(FlagsType &)>;
+    using ArgumentsType = std::vector<std::string>;
+    using CommandCallback = std::function<void(FlagsType &, ArgumentsType &)>;
 
     class Command {
     public:
         std::string name;
         std::string description;
         std::string example;
-        std::map<std::string, Flag> commandFlags;
+        std::map<std::string, Flag> flags;
         CommandCallback action;
+        int argumentsCount;
+        bool canContainEmptyArgumentList;
 
     public:
-        Command(std::string name, std::string description, std::string example, const std::vector<Flag> &commandFlags, CommandCallback action)
-            : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)) {
-            for (auto &flag : commandFlags) {
-                this->commandFlags.insert(std::make_pair(flag.name, flag));
+        Command(std::string name, std::string description, std::string example, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
+            for (auto &flag : flags) {
+                this->flags.insert(std::make_pair(flag.name, flag));
             }
         };
     };
-}
+}// namespace cli

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
-#include "Cli/Cli.hpp"
-//#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
+//#include "Cli/Cli.hpp"
+#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
 
 void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,56 +2,59 @@
 #include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
 
-void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments
-void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printHello
-void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printName
-void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printArguments
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printHello
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printName
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
 
 int main(int argc, char **argv) {
     auto cli = cli::Cli();
     cli.setDescriptionMaxWidth(7);
 
     try {
-        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1)    // Добавляем команду printArguments
-           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                                 // Добавляем команду printHello
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1) // Добавляем команду printArguments
+           .command("printTwoArguments", "Displays the passed arguments", "", {}, func, 2)
+           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                              // Добавляем команду printHello
            .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
-                    {
-                        cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),                                  // Объявляем флаг "--name" для команды printName
-                        cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)                            // Объявляем флаг "--surname" для команды printName
-                    },func3)                                                                                                                                                   // Добавляем команду printName и указываем флаги name и surname
-           .command("printFlagsAndArguments", "Displays the passed flags and arguments","$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
-        {
-                        cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),                             // Объявляем флаг "--dir" для команды printName
-                    }, func4, -1)                                                                                                                         // Добавляем команду printFlagsAndArguments
-           .parse(argc, argv);                                                                                                                                          // Обязательно вызываем функцию parse c аргументами argc и argv
-    } catch (const std::invalid_argument &error) {                                                                                                                         // Обрабатываем какие-либо ошибки
-        std::cout << error.what() << "\n";
-        return 2;                                                                                                                                                          // код завершения программы при ошибке
+                         {
+                                 cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),              // Объявляем флаг "--name" для команды printName
+                                 cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)        // Объявляем флаг "--surname" для команды printName
+                         },
+                         func3)                                                                                                                                         // Добавляем команду printName и указываем флаги name и surname
+           .command("printFlagsAndArguments", "Displays the passed flags and arguments", "$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
+                         {
+                                 cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),         // Объявляем флаг "--dir" для команды printName
+                         },
+                         func4, -1)                                                                                                                // Добавляем команду printFlagsAndArguments
+                .parse(argc, argv);                                                                                                                                  // Обязательно вызываем функцию parse c аргументами argc и argv
+    } catch (const std::invalid_argument &error) {                                                                                                                      // Обрабатываем какие-либо ошибки
+        std::cout << error.what() << "\n";                                                                                                                              // Обязательно при выводе ошибок поставить символ переноса строки, иначе возможен вывод странных символов
+        return 2;                                                                                                                                                       // код завершения программы при ошибке
     }
     return 0;
 }
 
 
-void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {           // Определение функции команды printArguments
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printArguments
     std::cout << "Arguments: \n";
     for (auto &arg : parsedArguments) {
         std::cout << arg << "\n";
     }
 }
 
-void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {          // Определение функции команды printHello
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printHello
     std::cout << "Hello!\n";
 }
 
-void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {          // Определение функции команды printName
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printName
     std::cout << "Hello "
               << parsedFlags.at("name").value << " "
               << parsedFlags.at("surname").value << "!\n";
 }
 
-void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {           // Определение функции команды printArguments
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printFlagsAndArguments
     std::cout << "Flags: \n";
-    for (auto &flag: parsedFlags) {
+    for (auto &flag : parsedFlags) {
         std::cout << flag.first << " -> " << flag.second.value << "\n";
     }
     std::cout << "Arguments: \n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,31 +1,61 @@
-//#include "Cli/Cli.hpp"
-#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
+#include "Cli/Cli.hpp"
+//#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
-void func(cli::FlagsType &parsedFlags); // Объявляем функцию, которая будет вызывать при вызове команды printHello
-void func2(cli::FlagsType &parsedFlags);// Объявляем функцию, которая будет вызывать при вызове команды printName
+
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printHello
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printName
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
 
 int main(int argc, char **argv) {
     auto cli = cli::Cli();
-    cli.setDescriptionMaxWidth(10);
+    cli.setDescriptionMaxWidth(7);
+
     try {
-        cli.command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func)// Добавляем команду printHello
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1)    // Добавляем команду printArguments
+           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                                 // Добавляем команду printHello
            .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
-           {
-                          cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),
-                          cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)
-                        },func2)            // Добавляем команду printName и указываем флаги name и surname
-                .parse(argc, argv);            // Обязательно вызываем функцию parse c аргументами argc и argv
-    } catch (const std::invalid_argument &error) {// Обрабатываем какие-либо ошибки
+                    {
+                        cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),                                  // Объявляем флаг "--name" для команды printName
+                        cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)                            // Объявляем флаг "--surname" для команды printName
+                    },func3)                                                                                                                                                   // Добавляем команду printName и указываем флаги name и surname
+           .command("printFlagsAndArguments", "Displays the passed flags and arguments","$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
+        {
+                        cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),                             // Объявляем флаг "--dir" для команды printName
+                    }, func4, -1)                                                                                                                         // Добавляем команду printFlagsAndArguments
+           .parse(argc, argv);                                                                                                                                          // Обязательно вызываем функцию parse c аргументами argc и argv
+    } catch (const std::invalid_argument &error) {                                                                                                                         // Обрабатываем какие-либо ошибки
         std::cout << error.what() << "\n";
-        return 2;// код завершения программы при ошибке
+        return 2;                                                                                                                                                          // код завершения программы при ошибке
     }
     return 0;
 }
 
-void func(cli::FlagsType &parsedFlags) {// Определение функции команды printHello
+
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {           // Определение функции команды printArguments
+    std::cout << "Arguments: \n";
+    for (auto &arg : parsedArguments) {
+        std::cout << arg << "\n";
+    }
+}
+
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {          // Определение функции команды printHello
     std::cout << "Hello!\n";
 }
 
-void func2(cli::FlagsType &parsedFlags) {// Определение функции команды printName
-    std::cout << "Hello " << parsedFlags.at("name").value << " " << parsedFlags.at("surname").value << "!\n";
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {          // Определение функции команды printName
+    std::cout << "Hello "
+              << parsedFlags.at("name").value << " "
+              << parsedFlags.at("surname").value << "!\n";
+}
+
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {           // Определение функции команды printArguments
+    std::cout << "Flags: \n";
+    for (auto &flag: parsedFlags) {
+        std::cout << flag.first << " -> " << flag.second.value << "\n";
+    }
+    std::cout << "Arguments: \n";
+    for (auto &arg : parsedArguments) {
+        std::cout << arg << "\n";
+    }
 }

--- a/tests/current_results/1.txt
+++ b/tests/current_results/1.txt
@@ -4,20 +4,38 @@ Usage:
    command [flags] [arguments]
 
 Commands:
-  help                               Show help  
-                                     information.
-  printHello                         Displays the 
-                                     word "Hell-
-                                     o!". 
-  printName                          Displays "Hello 
-                                     [entered nam-
-                                     e]!". 
+  help                               Show help 
+                                     informa-
+                                     tion. 
+  printArguments                     Displays 
+                                     the passed
+                                     arguments
+  printFlagsAndArguments             Displays 
+                                     the passed
+                                     flags and
+                                     arguments
     Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that 
-                                     accepts a 
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that 
-                                     accepts a 
-                                     surname for
-                                     entry. 
+      -d, --dir=VALUE                A flag  
+                                     that acc-
+                                     epts a 
+                                     directory
+                                     as input.
+  printHello                         Displays 
+                                     the word
+                                     "Hello!".
+  printName                          Displays 
+                                     "Hello 
+                                     [entered
+                                     name]!".
+    Flags:
+      -n, --name=VALUE[REQUIRED]     A flag  
+                                     that acc-
+                                     epts a 
+                                     name as 
+                                     input. 
+      -s, --surname=VALUE[REQUIRED]  A flag  
+                                     that acc-
+                                     epts a 
+                                     surname
+                                     for entry.
 

--- a/tests/current_results/1.txt
+++ b/tests/current_results/1.txt
@@ -38,4 +38,7 @@ Commands:
                                      epts a 
                                      surname
                                      for entry.
+  printTwoArguments                  Displays 
+                                     the passed
+                                     arguments
 

--- a/tests/current_results/2.txt
+++ b/tests/current_results/2.txt
@@ -2,24 +2,28 @@ Usage:
    command [flags] [arguments]
 
 Commands:
-  printName                          Displays "Hello 
-                                     [entered nam-
-                                     e]!". 
+  printName                          Displays 
+                                     "Hello 
+                                     [entered
+                                     name]!".
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that 
-                                     accepts a 
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that 
-                                     accepts a 
-                                     surname for
-                                     entry. 
+      -n, --name=VALUE[REQUIRED]     A flag  
+                                     that acc-
+                                     epts a 
+                                     name as 
+                                     input. 
+      -s, --surname=VALUE[REQUIRED]  A flag  
+                                     that acc-
+                                     epts a 
+                                     surname
+                                     for entry.
 	Example:
       $ printName -n Name
       >>> Hello Name!
 
-  printHello                         Displays the 
-                                     word "Hell-
-                                     o!". 
+  printHello                         Displays 
+                                     the word
+                                     "Hello!".
 	Example:
       $ printHello 
       >>> Hello!

--- a/tests/current_results/3.txt
+++ b/tests/current_results/3.txt
@@ -2,17 +2,21 @@ Usage:
    command [flags] [arguments]
 
 Command:
-  printName                          Displays "Hello 
-                                     [entered nam-
-                                     e]!". 
+  printName                          Displays 
+                                     "Hello 
+                                     [entered
+                                     name]!".
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that 
-                                     accepts a 
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that 
-                                     accepts a 
-                                     surname for
-                                     entry. 
+      -n, --name=VALUE[REQUIRED]     A flag  
+                                     that acc-
+                                     epts a 
+                                     name as 
+                                     input. 
+      -s, --surname=VALUE[REQUIRED]  A flag  
+                                     that acc-
+                                     epts a 
+                                     surname
+                                     for entry.
 	Example:
       $ printName -n Name
       >>> Hello Name!

--- a/tests/current_results/5.txt
+++ b/tests/current_results/5.txt
@@ -1,0 +1,5 @@
+Flags: 
+dir -> directory/
+Arguments: 
+file1.txt
+file2.txt

--- a/tests/expected_results/1.txt
+++ b/tests/expected_results/1.txt
@@ -5,19 +5,37 @@ Usage:
 
 Commands:
   help                               Show help
-                                     information.
-  printHello                         Displays the
-                                     word "Hell-
-                                     o!".
-  printName                          Displays "Hello
-                                     [entered nam-
-                                     e]!".
+                                     informa-
+                                     tion.
+  printArguments                     Displays
+                                     the passed
+                                     arguments
+  printFlagsAndArguments             Displays
+                                     the passed
+                                     flags and
+                                     arguments
     Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that
-                                     accepts a
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that
-                                     accepts a
-                                     surname for
-                                     entry.
+      -d, --dir=VALUE                A flag
+                                     that acc-
+                                     epts a
+                                     directory
+                                     as input.
+  printHello                         Displays
+                                     the word
+                                     "Hello!".
+  printName                          Displays
+                                     "Hello
+                                     [entered
+                                     name]!".
+    Flags:
+      -n, --name=VALUE[REQUIRED]     A flag
+                                     that acc-
+                                     epts a
+                                     name as
+                                     input.
+      -s, --surname=VALUE[REQUIRED]  A flag
+                                     that acc-
+                                     epts a
+                                     surname
+                                     for entry.
 

--- a/tests/expected_results/1.txt
+++ b/tests/expected_results/1.txt
@@ -38,4 +38,6 @@ Commands:
                                      epts a
                                      surname
                                      for entry.
-
+  printTwoArguments                  Displays
+                                     the passed
+                                     arguments

--- a/tests/expected_results/2.txt
+++ b/tests/expected_results/2.txt
@@ -2,24 +2,28 @@ Usage:
    command [flags] [arguments]
 
 Commands:
-  printName                          Displays "Hello
-                                     [entered nam-
-                                     e]!".
+  printName                          Displays
+                                     "Hello
+                                     [entered
+                                     name]!".
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that
-                                     accepts a
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that
-                                     accepts a
-                                     surname for
-                                     entry.
+      -n, --name=VALUE[REQUIRED]     A flag
+                                     that acc-
+                                     epts a
+                                     name as
+                                     input.
+      -s, --surname=VALUE[REQUIRED]  A flag
+                                     that acc-
+                                     epts a
+                                     surname
+                                     for entry.
 	Example:
       $ printName -n Name
       >>> Hello Name!
 
-  printHello                         Displays the
-                                     word "Hell-
-                                     o!".
+  printHello                         Displays
+                                     the word
+                                     "Hello!".
 	Example:
       $ printHello
       >>> Hello!

--- a/tests/expected_results/3.txt
+++ b/tests/expected_results/3.txt
@@ -2,17 +2,21 @@ Usage:
    command [flags] [arguments]
 
 Command:
-  printName                          Displays "Hello
-                                     [entered nam-
-                                     e]!".
+  printName                          Displays
+                                     "Hello
+                                     [entered
+                                     name]!".
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag that
-                                     accepts a
-                                     name as input.
-      -s, --surname=VALUE[REQUIRED]  A flag that
-                                     accepts a
-                                     surname for
-                                     entry.
+      -n, --name=VALUE[REQUIRED]     A flag
+                                     that acc-
+                                     epts a
+                                     name as
+                                     input.
+      -s, --surname=VALUE[REQUIRED]  A flag
+                                     that acc-
+                                     epts a
+                                     surname
+                                     for entry.
 	Example:
       $ printName -n Name
       >>> Hello Name!

--- a/tests/expected_results/5.txt
+++ b/tests/expected_results/5.txt
@@ -1,0 +1,5 @@
+Flags:
+dir -> directory/
+Arguments:
+file1.txt
+file2.txt

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -21,7 +21,7 @@ public:
         std::cout << "Hello " << parsedFlags.at("name").value << " " << parsedFlags.at("surname").value << "!\n";
     }
 
-    static void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {           // Определение функции команды printArguments
+    static void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {
         std::cout << "Flags: \n";
         for (auto &flag: parsedFlags) {
             std::cout << flag.first << " -> " << flag.second.value << "\n";


### PR DESCRIPTION
Added command arguments.

Now it is possible to pass the arguments to the commands.

For example: `$ ./cli cmd arg1 arg2`

P.S. `arg1` and `arg2` is command(`cmd`) arguments.