### PR TITLE
Added function overload for commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ add_subdirectory(
 set(SOURCE_FILES src/main.cpp src/Cli/Cli.cpp src/Cli/Cli.hpp src/Flag/Flag.hpp src/Command/Command.hpp)
 
 #Main target
-add_executable(cli ${SOURCE_FILES})
-#add_executable(cli src/main.cpp build/cli.hpp)
+#add_executable(cli ${SOURCE_FILES})
+add_executable(cli src/main.cpp build/cli.hpp)
 
 configure_file(cli_config.h.in ../src/cli_config.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,11 @@ add_subdirectory(
         "${CMAKE_CURRENT_SOURCE_DIR}/googletest"
         "googletest")
 
-set(SOURCE_FILES src/main.cpp src/Cli/Cli.cpp src/Cli/Cli.hpp src/Flag/Flag.cpp src/Flag/Flag.hpp src/Command/Command.cpp src/Command/Command.hpp)
+set(SOURCE_FILES src/main.cpp src/Cli/Cli.cpp src/Cli/Cli.hpp src/Flag/Flag.hpp src/Command/Command.hpp)
 
 #Main target
-#add_executable(cli ${SOURCE_FILES})
-add_executable(cli src/main.cpp build/cli.hpp)
+add_executable(cli ${SOURCE_FILES})
+#add_executable(cli src/main.cpp build/cli.hpp)
 
 configure_file(cli_config.h.in ../src/cli_config.h)
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,24 @@ auto cli = cli::Cli();
 > ❗ При использовании этого метода стоит обращать внимание, что существует реализация переноса слов.  
 > Перенос работает по правилу "не оставлять меньше 3 символов до/после дефиса".
 
-2. Чтобы описать `команду` нужно использовать следующий синтаксис: 
+2. Чтобы описать `команду` можно использовать один из вариантов ниже: 
 
 ```c++
 command(name, description, example, {flags}, action, argumentsCount = 0, canContainEmptyArgumentList = false);
 ```
+
+```c++
+command(name, description, example, action, argumentsCount = 0, canContainEmptyArgumentList = false);
+```
+
+```c++
+command(name, description, {flags}, action, argumentsCount = 0, canContainEmptyArgumentList = false);
+```
+
+```c++
+command(name, description, action, argumentsCount = 0, canContainEmptyArgumentList = false);
+```
+
 | Поле                          | Тип               | Описание                                                                                                    |
 |-------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------|
 | `name`                        | `string`          | имя команды                                                                                                 |
@@ -196,9 +209,9 @@ int main(int argc, char **argv) {
     cli.setDescriptionMaxWidth(7); // Задаём ширину описания
 
     try {
-        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1) // Добавляем команду printArguments
-           .command("printTwoArguments", "Displays the passed arguments", "", {}, func, 2)                                                                              // Добавляем команду printTwoArguments
-           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                              // Добавляем команду printHello
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", func, -1)     // Добавляем команду printArguments
+           .command("printTwoArguments", "Displays the passed arguments", func, 2)                                                                                      // Добавляем команду printTwoArguments
+           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", func2)                                                                  // Добавляем команду printHello
            .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
                          {
                                  cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),                                                            // Объявляем флаг "--name" для команды printName

--- a/build-lib.py
+++ b/build-lib.py
@@ -24,8 +24,8 @@ except FileExistsError:
     
 #Чтение всех файлов из path и объединение всё в переменную code
 #############################################################    
-paths = ["src/Flag/Flag.hpp", "src/Flag/Flag.cpp", "src/Command/Command.hpp", "src/Cli/Cli.hpp", 
-"src/Cli/Cli.cpp", "src/Command/Command.cpp", "src/cli_config.h"] # !Порядок файлов важен (запись в code идёт именно в этом порядке)
+paths = ["src/Flag/Flag.hpp", "src/Command/Command.hpp", "src/Cli/Cli.hpp",
+"src/Cli/Cli.cpp", "src/cli_config.h"] # !Порядок файлов важен (запись в code идёт именно в этом порядке)
 code = ""
 includes = "#pragma once\n\n" # Собираем сюда все подключаемые библиотеки, чтобы потом в файле поместить их сверху
 defines = "\n"

--- a/build/cli.hpp
+++ b/build/cli.hpp
@@ -47,6 +47,23 @@ namespace cli {
         bool canContainEmptyArgumentList;
 
     public:
+        //cli.command("Name", "Description", "Example", action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, std::string example, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+                : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {};
+
+        //cli.command("Name", "Description", {Flags}, action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
+            for (auto &flag : flags) {
+                this->flags.insert(std::make_pair(flag.name, flag));
+            }
+        };
+
+        //cli.command("Name", "Description", action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {};
+
+        // cli.command("Name", "Description", "Example", {Flags}, action, argumentsCount, canContainEmptyArgumentList)
         Command(std::string name, std::string description, std::string example, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
             : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
             for (auto &flag : flags) {
@@ -69,6 +86,9 @@ namespace cli {
                 {"blue", "\x1B[34m"},
                 {"white", "\x1B[37m"}};
 
+        Cli &command(const std::string &name, const std::string &description, const std::string &example, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
+        Cli &command(const std::string &name, const std::string &description, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
+        Cli &command(const std::string &name, const std::string &description, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &setDescriptionMaxWidth(int value = 50);
 
@@ -92,6 +112,24 @@ namespace cli {
                                                                                   }))};
     };
 }// namespace cli
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, example, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::vector<Flag> &commandFlag, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
 cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
     Command cmd = Command(name, description, example, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
     commands.insert(std::make_pair(name, cmd));

--- a/src/Cli/Cli.cpp
+++ b/src/Cli/Cli.cpp
@@ -1,5 +1,23 @@
 #include "Cli.hpp"
 
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, example, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::vector<Flag> &commandFlag, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
+cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const cli::CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
+    Command cmd = Command(name, description, action, argumentsCount, canContainEmptyArgumentList);
+    commands.insert(std::make_pair(name, cmd));
+    return *this;
+}
+
 cli::Cli &cli::Cli::command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount, bool canContainEmptyArgumentList) {
     Command cmd = Command(name, description, example, commandFlag, action, argumentsCount, canContainEmptyArgumentList);
     commands.insert(std::make_pair(name, cmd));

--- a/src/Cli/Cli.hpp
+++ b/src/Cli/Cli.hpp
@@ -17,6 +17,9 @@ namespace cli {
                 {"blue", "\x1B[34m"},
                 {"white", "\x1B[37m"}};
 
+        Cli &command(const std::string &name, const std::string &description, const std::string &example, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
+        Cli &command(const std::string &name, const std::string &description, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
+        Cli &command(const std::string &name, const std::string &description, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &command(const std::string &name, const std::string &description, const std::string &example, const std::vector<Flag> &commandFlag, const CommandCallback &action, int argumentsCount = 0, bool canContainEmptyArgumentList = false);
         Cli &setDescriptionMaxWidth(int value = 50);
 

--- a/src/Command/Command.cpp
+++ b/src/Command/Command.cpp
@@ -1,1 +1,0 @@
-#include "Command.hpp"

--- a/src/Command/Command.hpp
+++ b/src/Command/Command.hpp
@@ -24,6 +24,23 @@ namespace cli {
         bool canContainEmptyArgumentList;
 
     public:
+        //cli.command("Name", "Description", "Example", action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, std::string example, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+                : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {};
+
+        //cli.command("Name", "Description", {Flags}, action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
+            for (auto &flag : flags) {
+                this->flags.insert(std::make_pair(flag.name, flag));
+            }
+        };
+
+        //cli.command("Name", "Description", action, argumentsCount, canContainEmptyArgumentList)
+        Command(std::string name, std::string description, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
+            : name(std::move(name)), description(std::move(description)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {};
+
+        // cli.command("Name", "Description", "Example", {Flags}, action, argumentsCount, canContainEmptyArgumentList)
         Command(std::string name, std::string description, std::string example, const std::vector<Flag> &flags, CommandCallback action, int argumentsCount = 0, bool canContainEmptyArgumentList = false)
             : name(std::move(name)), description(std::move(description)), example(std::move(example)), action(std::move(action)), argumentsCount(argumentsCount), canContainEmptyArgumentList(canContainEmptyArgumentList) {
             for (auto &flag : flags) {

--- a/src/Flag/Flag.cpp
+++ b/src/Flag/Flag.cpp
@@ -1,1 +1,0 @@
-#include "Flag.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
-#include "Cli/Cli.hpp"
-//#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
+#include "../build/cli.hpp" // Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
 
 void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments
@@ -8,25 +7,23 @@ void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); //
 void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
 
 int main(int argc, char **argv) {
-    auto cli = cli::Cli();
-    cli.setDescriptionMaxWidth(7);
+    auto cli = cli::Cli();               // Создаём объект класса Cli
+    cli.setDescriptionMaxWidth(7); // Задаём ширину описания
 
     try {
         cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", func, -1)     // Добавляем команду printArguments
-           .command("printTwoArguments", "Displays the passed arguments", func, 2)
-           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", func2)                                                                  // Добавляем команду printHello
-           .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
+                .command("printTwoArguments", "Displays the passed arguments", func, 2)                                                                                      // Добавляем команду printTwoArguments
+                .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", func2)                                                                  // Добавляем команду printHello
+                .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
                          {
-                                 cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),              // Объявляем флаг "--name" для команды printName
-                                 cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)        // Объявляем флаг "--surname" для команды printName
-                         },
-                         func3)                                                                                                                                         // Добавляем команду printName и указываем флаги name и surname
-           .command("printFlagsAndArguments", "Displays the passed flags and arguments", "$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
+                                 cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),                                                            // Объявляем флаг "--name" для команды printName
+                                 cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)                                                      // Объявляем флаг "--surname" для команды printName
+                         }, func3)                                                                                                                                      // Добавляем команду printName и указываем флаги name и surname
+                .command("printFlagsAndArguments", "Displays the passed flags and arguments", "$ printFlagsAndArguments file1.txt --dir value file2.txt\n>>> Flags:\n    flag -> value\n Arguments:\n    file1.txt\n    file2.txt",
                          {
-                                 cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),         // Объявляем флаг "--dir" для команды printName
-                         },
-                         func4, -1)                                                                                                                // Добавляем команду printFlagsAndArguments
-                .parse(argc, argv);                                                                                                                                  // Обязательно вызываем функцию parse c аргументами argc и argv
+                                 cli::Flag("dir", "d", "A flag that accepts a directory as input.", false, true),                                                       // Объявляем флаг "--dir" для команды printName
+                         }, func4, -1)                                                                                                                                  // Добавляем команду printFlagsAndArguments
+                .parse(argc, argv);                                                                                                                                     // Обязательно вызываем функцию parse c аргументами argc и argv
     } catch (const std::invalid_argument &error) {                                                                                                                      // Обрабатываем какие-либо ошибки
         std::cout << error.what() << "\n";                                                                                                                              // Обязательно при выводе ошибок поставить символ переноса строки, иначе возможен вывод странных символов
         return 2;                                                                                                                                                       // код завершения программы при ошибке

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,20 @@
-//#include "Cli/Cli.hpp"
-#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
+#include "Cli/Cli.hpp"
+//#include "../build/cli.hpp"// Подключаем нашу библиотеку для использования CLI (путь до библиотеки может отличаться)
 
 
-void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printArguments
-void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printHello
-void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printName
-void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);// Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments);  // Объявляем функцию, которая будет вызывать при вызове команды printArguments
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printHello
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printName
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments); // Объявляем функцию, которая будет вызывать при вызове команды printFlagsAndArguments
 
 int main(int argc, char **argv) {
     auto cli = cli::Cli();
     cli.setDescriptionMaxWidth(7);
 
     try {
-        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1) // Добавляем команду printArguments
-           .command("printTwoArguments", "Displays the passed arguments", "", {}, func, 2)
-           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)                                                              // Добавляем команду printHello
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", func, -1)     // Добавляем команду printArguments
+           .command("printTwoArguments", "Displays the passed arguments", func, 2)
+           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", func2)                                                                  // Добавляем команду printHello
            .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
                          {
                                  cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),              // Объявляем флаг "--name" для команды printName
@@ -35,24 +35,24 @@ int main(int argc, char **argv) {
 }
 
 
-void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printArguments
+void func(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printArguments
     std::cout << "Arguments: \n";
     for (auto &arg : parsedArguments) {
         std::cout << arg << "\n";
     }
 }
 
-void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printHello
+void func2(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printHello
     std::cout << "Hello!\n";
 }
 
-void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printName
+void func3(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printName
     std::cout << "Hello "
               << parsedFlags.at("name").value << " "
               << parsedFlags.at("surname").value << "!\n";
 }
 
-void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) {// Определение функции команды printFlagsAndArguments
+void func4(cli::FlagsType &parsedFlags, cli::ArgumentsType &parsedArguments) { // Определение функции команды printFlagsAndArguments
     std::cout << "Flags: \n";
     for (auto &flag : parsedFlags) {
         std::cout << flag.first << " -> " << flag.second.value << "\n";

--- a/tests/current_results/3.txt
+++ b/tests/current_results/3.txt
@@ -2,22 +2,21 @@ Usage:
    command [flags] [arguments]
 
 Command:
-  printName                          Displays 
-                                     "Hello 
-                                     [entered
-                                     name]!".
+  printFlagsAndArguments  Displays 
+                          the passed
+                          flags and
+                          arguments
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag  
-                                     that acc-
-                                     epts a 
-                                     name as 
-                                     input. 
-      -s, --surname=VALUE[REQUIRED]  A flag  
-                                     that acc-
-                                     epts a 
-                                     surname
-                                     for entry.
+      -d, --dir=VALUE     A flag  
+                          that acc-
+                          epts a 
+                          directory
+                          as input.
 	Example:
-      $ printName -n Name
-      >>> Hello Name!
+      $ printFlagsAndArguments file1.txt --dir value file2.txt
+      >>> Flags:
+          flag -> value
+       Arguments:
+          file1.txt
+          file2.txt
 

--- a/tests/expected_results/3.txt
+++ b/tests/expected_results/3.txt
@@ -2,22 +2,21 @@ Usage:
    command [flags] [arguments]
 
 Command:
-  printName                          Displays
-                                     "Hello
-                                     [entered
-                                     name]!".
+  printFlagsAndArguments  Displays
+                          the passed
+                          flags and
+                          arguments
 	Flags:
-      -n, --name=VALUE[REQUIRED]     A flag
-                                     that acc-
-                                     epts a
-                                     name as
-                                     input.
-      -s, --surname=VALUE[REQUIRED]  A flag
-                                     that acc-
-                                     epts a
-                                     surname
-                                     for entry.
+      -d, --dir=VALUE     A flag
+                          that acc-
+                          epts a
+                          directory
+                          as input.
 	Example:
-      $ printName -n Name
-      >>> Hello Name!
+      $ printFlagsAndArguments file1.txt --dir value file2.txt
+      >>> Flags:
+          flag -> value
+       Arguments:
+          file1.txt
+          file2.txt
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -35,10 +35,10 @@ public:
     void SetUp() override {
         cli.setDescriptionMaxWidth(7);
 
-        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n    file2.txt", {}, func, -1)
-           .command("printTwoArguments", "Displays the passed arguments", "", {}, func, 2)
-           .command("printHello", "Displays the word \"Hello!\".", "$ printHello \n>>> Hello!", {}, func2)
-           .command("printName", "Displays \"Hello [entered name]!\".", "$ printName -n Name\n>>> Hello Name!",
+        cli.command("printArguments", "Displays the passed arguments", "$ printArguments file1.txt file2.txt\n>>> Arguments:\n file1.txt\n file2.txt", func, -1)
+           .command("printTwoArguments", "Displays the passed arguments", func, 2)
+           .command("printHello", "Displays the word \"Hello!\".", func2)
+           .command("printName", "Displays \"Hello [entered name]!\".",
                          {
                             cli::Flag("name", "n", "A flag that accepts a name as input.", true, true),
                             cli::Flag("surname", "s", "A flag that accepts a surname for entry.", true, true)
@@ -287,7 +287,7 @@ TEST_F(CliFixture, TestingPrintCmdHelpFunction_ManyCommands) {
 TEST_F(CliFixture, TestingPrintCmdHelpFunction_OneCommand) {
     //Average
     int argc = 4;
-    const std::string cmdArguments = "./cli --nocolor help printName";
+    const std::string cmdArguments = "./cli --nocolor help printFlagsAndArguments";
     char **argv = initArgv(argc, cmdArguments);
     const std::string fileName = "3.txt";
 


### PR DESCRIPTION
Now you can declare command four ways
``` c++  
command(name, description, example, {flags}, action, argumentsCount = 0, canContainEmptyArgumentList = false);
```
``` c++  
command(name, description, example, action, argumentsCount = 0, canContainEmptyArgumentList = false);
```
``` c++ 
command(name, description, {flags}, action, argumentsCount = 0, canContainEmptyArgumentList = false);
```
``` c++ 
command(name, description, action, argumentsCount = 0, canContainEmptyArgumentList = false);
```